### PR TITLE
gitignore: remove .ditz-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 conf.yml
-.ditz-config
 *.swp
 log/*.yml
 *.bak


### PR DESCRIPTION
Shouldn't `.ditz-config` be included in the repo, since it contains the project-level Ditz metadata, which should be shared between developers?