### PR TITLE
gitignore: remove *.pyc since this is no longer a python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ log/*.yml
 tmp
 firmware/arduino/arduino-0017/*
 firmware/arduino/arduino-0017
-*.pyc
 .ropeproject


### PR DESCRIPTION
This isn't a Python project (any more, anyway?), so it probably shouldn't have the `*.pyc` in its `.gitignore`, right?